### PR TITLE
Guardar el modelo correcto de ARIMA en disco

### DIFF
--- a/src/pipeline/training.py
+++ b/src/pipeline/training.py
@@ -80,8 +80,7 @@ class TimeSeriesTrainer:
                 "results_df": results_df,
             }
         else:
-            arima_model = ARIMA(data, order=(param_p, param_d, param_q))
-            model = arima_model.fit()  # Fit the model
+            model = ARIMA(data, order=(param_p, param_d, param_q)).fit()
             results_df = None
             best_order = (param_p, param_d, param_q)
         # Store model


### PR DESCRIPTION
El código de entrenamiento de ARIMA estaba guardando el modelo "unfitted", el cual no permite hacer el forecast. Este hotfix soluciona ese problema.